### PR TITLE
fix: stabilize cdk-erigon rollup bootstrap on external L1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ templates/contract-deploy/dynamic-kurtosis-conf.json
 templates/contract-deploy/genesis.json
 anvil_state.json
 combined.json
+
+*.patch

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -170,12 +170,18 @@ def get_keystores_artifacts(plan, args):
         service_name="contracts" + args["deployment_suffix"],
         src="/opt/zkevm/claimsponsor.keystore",
     )
+    agglayer_keystore_artifact = plan.store_service_files(
+        name="agglayer-keystore-cdk",
+        service_name="contracts" + args["deployment_suffix"],
+        src="/opt/zkevm/agglayer.keystore",
+    )
     return struct(
         sequencer=sequencer_keystore_artifact,
         aggregator=aggregator_keystore_artifact,
         proofsigner=proofsigner_keystore_artifact,
         dac=dac_keystore_artifact,
         claim_sponsor=claim_sponsor_keystore_artifact,
+        agglayer=agglayer_keystore_artifact,
     )
 
 

--- a/deploy_agglayer_contracts.star
+++ b/deploy_agglayer_contracts.star
@@ -199,6 +199,18 @@ def run(plan, args, deployment_stages, op_stack_args):
     files = {
         "/opt/zkevm": Directory(persistent_key="zkevm-artifacts"),
         "/opt/contract-deploy/": Directory(artifact_names=artifacts),
+        # Mount cdk-erigon tools (currently: smt-genesis binary) so the
+        # run-create-agglayer-rollup.sh script can pre-compute the SMT
+        # genesis root from dynamic-*-allocs.json before the L1 rollup
+        # is created. See doc-report/fix-plan-invalidProof.md for context.
+        "/opt/cdk-erigon/": Directory(
+            artifact_names=[
+                plan.upload_files(
+                    src="./static_files/cdk-erigon-tools/",
+                    name="cdk-erigon-tools",
+                ),
+            ],
+        ),
     }
 
     # Create op-succinct artifacts
@@ -331,7 +343,7 @@ def run(plan, args, deployment_stages, op_stack_args):
                 command=[
                     "/bin/bash",
                     "-c",
-                    "set -o pipefile; (chmod +x {0} && {0}) 2>&1 | tee /opt/run-deploy-l1-agglayer-core-contracts.log".format(
+                    "set -euo pipefail; (chmod +x {0} && {0}) 2>&1 | tee /opt/run-deploy-l1-agglayer-core-contracts.log".format(
                         "/opt/contract-deploy/run-deploy-l1-agglayer-core-contracts.sh"
                     ),
                 ]
@@ -344,9 +356,20 @@ def run(plan, args, deployment_stages, op_stack_args):
                 command=[
                     "/bin/bash",
                     "-c",
-                    "set -o pipefile; (chmod +x {0} && {0}) 2>&1 | tee /opt/run-create-agglayer-rollup.log".format(
+                    "set -euo pipefail; (chmod +x {0} && {0}) 2>&1 | tee /opt/run-create-agglayer-rollup.log".format(
                         "/opt/contract-deploy/run-create-agglayer-rollup.sh"
                     ),
+                ]
+            ),
+        )
+        plan.exec(
+            description="Validating generated contract artifacts",
+            service_name=contracts_service_name,
+            recipe=ExecRecipe(
+                command=[
+                    "/bin/bash",
+                    "-c",
+                    "set -euo pipefail; test -s /opt/zkevm/combined.json; test -s /opt/zkevm/genesis.json; jq -e '.polygonZkEVMBridgeAddress and .rollupAddress and .polTokenAddress and .admin and .polygonRollupManagerAddress' /opt/zkevm/combined.json >/dev/null",
                 ]
             ),
         )

--- a/deploy_l2_contracts.star
+++ b/deploy_l2_contracts.star
@@ -4,6 +4,22 @@ service_package = import_module("./lib/service.star")
 def run(plan, args, deploy_l2_contracts):
     l2_rpc_url = service_package.get_l2_rpc_url(plan, args)
 
+    # Use the sequencer URL for sending transactions.  The RPC-only node
+    # (cdk-erigon-rpc) does not execute transactions — it only writes
+    # headers from the DataStream — so `cast send` against it fails with
+    # IntrinsicGas.  The sequencer owns the tx-pool and the full state.
+    l2_sequencer_url = ""
+    if args.get("l2_sequencer_name", ""):
+        seq_svc = plan.get_service(
+            name=args["l2_sequencer_name"] + args["deployment_suffix"]
+        )
+        if "rpc" in seq_svc.ports:
+            l2_sequencer_url = "http://{}:{}".format(
+                seq_svc.ip_address, seq_svc.ports["rpc"].number
+            )
+    if not l2_sequencer_url:
+        l2_sequencer_url = l2_rpc_url.http
+
     # When funding accounts and deploying the contracts on l2, the
     # zkevm-contracts service is reused to reduce startup time. Since the l2
     # doesn't exist at the time the service is added to kurtosis, the
@@ -18,7 +34,7 @@ def run(plan, args, deploy_l2_contracts):
                 "/bin/sh",
                 "-c",
                 "export l2_rpc_url={0} && chmod +x {1} && {1} {2}".format(
-                    l2_rpc_url.http,
+                    l2_sequencer_url,
                     "/opt/contract-deploy/run-l2-contract-setup.sh",
                     str(deploy_l2_contracts).strip().lower(),
                 ),

--- a/input_parser.star
+++ b/input_parser.star
@@ -47,9 +47,9 @@ DEFAULT_IMAGES = {
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",
     "agglogger_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglogger:bf1f8c1",
     "anvil_image": "ghcr.io/foundry-rs/foundry:v1.0.0",
-    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.24",
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:local",
     "cdk_sovereign_erigon_node_image": "hermeznetwork/cdk-erigon:v2.63.0-rc4",  # Type-1 CDK Erigon Sovereign
-    "cdk_node_image": "ghcr.io/0xpolygon/cdk:0.5.4",
+    "cdk_node_image": "davidyoung2025/cdk:local",
     "cdk_validium_node_image": "ghcr.io/0xpolygon/cdk-validium-node:0.6.4-cdk.10",
     "db_image": "postgres:16.2",
     "geth_image": "ethereum/client-go:v1.16.2",
@@ -590,6 +590,9 @@ def parse_args(plan, user_args):
     deploy_cdk_erigon_node = deployment_stages.get("deploy_cdk_erigon_node", False)
     deploy_op_node = deployment_stages.get("deploy_optimism_rollup", False)
     l2_rpc_name = get_l2_rpc_name(deploy_cdk_erigon_node, deploy_op_node)
+    l2_sequencer_name = get_l2_sequencer_name(
+        deploy_cdk_erigon_node, deploy_op_node
+    )
 
     # Determine static ports, if specified.
     if not args.get("use_dynamic_ports", True):
@@ -611,6 +614,7 @@ def parse_args(plan, user_args):
 
     args = args | {
         "l2_rpc_name": l2_rpc_name,
+        "l2_sequencer_name": l2_sequencer_name,
         "sequencer_name": sequencer_name,
         "zkevm_rollup_fork_id": fork_id,
         "zkevm_rollup_fork_name": fork_name,
@@ -716,6 +720,18 @@ def get_l2_rpc_name(deploy_cdk_erigon_node, deploy_op_node):
     if deploy_cdk_erigon_node:
         return "cdk-erigon-rpc"
     return "zkevm-node-rpc"
+
+
+def get_l2_sequencer_name(deploy_cdk_erigon_node, deploy_op_node):
+    # The sequencer is the only node that maintains the full PlainState/
+    # History tables required to correctly unwind the SMT for witness
+    # generation.  For OP stack there is no separate sequencer service in
+    # the kurtosis deployment - fall back to the op-geth node.
+    if deploy_op_node:
+        return "op-el-1-op-geth-op-node"
+    if deploy_cdk_erigon_node:
+        return "cdk-erigon-sequencer"
+    return "zkevm-node-sequence-sender"
 
 
 def get_op_stack_args(plan, args, user_op_stack_args):

--- a/lib/cdk_node.star
+++ b/lib/cdk_node.star
@@ -26,6 +26,7 @@ def create_cdk_node_service_config(
                     keystore_artifact.aggregator,
                     keystore_artifact.sequencer,
                     keystore_artifact.claim_sponsor,
+                    keystore_artifact.agglayer,
                 ],
             ),
             "/data": Directory(
@@ -105,11 +106,64 @@ def get_cdk_node_ports(args):
 def get_cdk_node_cmd(args):
     binary_name = args.get("binary_name")
 
+    # Workaround: pre-seed the synchronizer fork_id table so that
+    # SequenceBatches events are not dropped with forkid=0.
+    # The L1 CreateNewRollup event carries forkID=0 in its data,
+    # and the RollupTypeMap ABI call returns a wrong value,
+    # leaving the fork_id table empty.  Inject the configured
+    # fork_id after cdk-node has finished its 0001.sql migration
+    # (which creates the fork_id table) but before it starts the
+    # synchronizer event loop.  We use a background launcher that
+    # polls for the fork_id table and then INSERTs the row.
+    fork_id = args.get("zkevm_rollup_fork_id", "12")
+    dq = chr(34)  # double quote
+    sq = chr(39)  # single quote
+    # shell command run by the side-car to inject the fork_id row
+    inject_cmd = (
+        "i=0; while [ $i -lt 30 ]; do "
+        + "if sqlite3 /tmp/aggregator_sync_db.sqlite "
+        + dq + "SELECT name FROM sqlite_master WHERE type='table' AND name='fork_id';" + dq
+        + " 2>/dev/null | grep -q fork_id; then "
+        + "sqlite3 /tmp/aggregator_sync_db.sqlite "
+        + dq + "INSERT OR IGNORE INTO fork_id (fork_id, from_batch_num, to_batch_num, version, block_num) "
+        + "VALUES (" + str(fork_id) + ", 1, 9223372036854775807, " + sq + "banana" + sq + ", 0);" + dq
+        + " && echo injected-forkid-" + str(fork_id) + " && break; fi; "
+        + "i=$((i+1)); sleep 1; done; "
+    )
+
+    # Workaround: fix cdk-node-config.toml genesisBlockNumber to match
+    # the createRollupBlockNumber from genesis.json.  The default value
+    # comes from zkevm_rollup_manager_block_number (the block where
+    # RollupManager contract itself was deployed, which is several
+    # blocks AFTER our rollup was actually created).  This causes the
+    # synchronizer to miss the InitialSequenceBatches event that emits
+    # batch 1, leaving the sequenced_batches table without batch 1
+    # forever, which blocks the aggregator from ever dispatching
+    # proof tasks.  Read the correct value from genesis.json and
+    # rewrite cdk-node-config.toml to use it.
+    patch_config_cmd = (
+        "GBN=$(awk -F: '/\"genesisBlockNumber\"/ {gsub(/[^0-9]/, \"\", $2); print $2; exit}' /etc/cdk/genesis.json); "
+        + "if [ -n \"$GBN\" ] && [ \"$GBN\" != \"0\" ]; then "
+        + "sed -i -E 's|^genesisBlockNumber[[:space:]]*=.*|genesisBlockNumber = \"'\"$GBN\"'\"|' "
+        + "/etc/cdk/cdk-node-config.toml; "
+        + "sed -i -E 's|^rollupCreationBlockNumber[[:space:]]*=.*|rollupCreationBlockNumber = \"'\"$GBN\"'\"|' "
+        + "/etc/cdk/cdk-node-config.toml; "
+        + "sed -i -E 's|^rollupManagerCreationBlockNumber[[:space:]]*=.*|rollupManagerCreationBlockNumber = \"'\"$GBN\"'\"|' "
+        + "/etc/cdk/cdk-node-config.toml; "
+        + "echo patched-genesis-block-number-to-$GBN; "
+        + "else echo 'failed to determine genesisBlockNumber from /etc/cdk/genesis.json' >&2; exit 1; fi; "
+    )
+
     service_command = [
-        "sleep 20 && cdk-node run "
+        "sleep 20 && ("
+        + inject_cmd
+        + ") & "
+        + patch_config_cmd
+        + "cdk-node run "
         + "--cfg=/etc/cdk/cdk-node-config.toml "
         + "--custom-network-file=/etc/cdk/genesis.json "
-        + "--components=sequence-sender,aggregator"
+        + "--components=sequence-sender,aggregator; "
+        + "wait"
     ]
 
     if args["consensus_contract_type"] == constants.CONSENSUS_TYPE.pessimistic:

--- a/static_files/cdk-erigon-tools/build.sh
+++ b/static_files/cdk-erigon-tools/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Build smt-genesis inside a Debian bookworm container so the resulting
+# binary is dynamically linked against the older glibc that ships in
+# kurtosis-cdk's agglayer-contracts image (node:22-bookworm, glibc 2.36).
+#
+# The binary must run inside the contracts container during
+# `run-create-agglayer-rollup.sh` to pre-compute the SMT genesis root that
+# is then written into L1 batchNumToStateRoot[0]. See
+# doc-report/fix-plan-invalidProof.md for context.
+#
+# Usage:
+#   ./build.sh
+#
+# Output:
+#   ../kurtosis-cdk/static_files/cdk-erigon-tools/smt-genesis
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Layout:
+#   $SCRIPT_DIR                       -> kurtosis-cdk/static_files/cdk-erigon-tools/
+#   $SCRIPT_DIR/../../../cdk-erigon   -> cdk-erigon repo (the source we build from)
+ERIGON_DIR="$(cd "$SCRIPT_DIR/../../../cdk-erigon" && pwd)"
+OUT_FILE="$SCRIPT_DIR/smt-genesis"
+
+echo "==> Building smt-genesis inside node:22-bookworm (matches contracts container)"
+
+docker run --rm \
+    -v "$ERIGON_DIR:/src" \
+    -w /src \
+    node:22-bookworm \
+    bash -c '
+        set -euo pipefail
+        apt-get update >/dev/null 2>&1
+        apt-get install -y --no-install-recommends \
+            gcc libc6-dev ca-certificates curl git >/dev/null 2>&1
+        if ! command -v go >/dev/null; then
+            curl -fsSL https://go.dev/dl/go1.23.4.linux-amd64.tar.gz -o /tmp/go.tgz
+            tar -C /usr/local -xzf /tmp/go.tgz
+        fi
+        export PATH=/usr/local/go/bin:$PATH
+        CGO_ENABLED=1 GOFLAGS="-mod=mod" \
+            /usr/local/go/bin/go build -buildvcs=false \
+                -tags "nosqlite,noboltdb" \
+                -o /src/cmd/read-smt-genesis/smt-genesis-bookworm \
+                ./cmd/read-smt-genesis/
+    '
+
+cp "$ERIGON_DIR/cmd/read-smt-genesis/smt-genesis-bookworm" "$OUT_FILE"
+rm -f "$ERIGON_DIR/cmd/read-smt-genesis/smt-genesis-bookworm"
+chmod +x "$OUT_FILE"
+
+echo "==> Built: $OUT_FILE"
+ls -la "$OUT_FILE"
+file "$OUT_FILE"
+echo
+echo "==> Smoke test (should print a 0x-prefixed 32-byte root):"
+"$OUT_FILE" --alloc "$ERIGON_DIR/core/allocs/hermez-etrog.json" 2>/dev/null

--- a/templates/cdk-erigon/config.yml
+++ b/templates/cdk-erigon/config.yml
@@ -102,7 +102,34 @@ zkevm.witness-memdb-size: 2GB
 # Enables full witness generation, which provides comprehensive proof data for transactions.
 # This can be useful for debugging and verification purposes.
 # Default: true
-zkevm.witness-full: false
+# zkevm.witness-full: false
+
+# Enable witness caching for batches. This caches witnesses in the DB during the stage loop,
+# avoiding the need to regenerate witnesses via SMT unwind for each RPC call.
+# This is crucial for networks with many unverified batches that need prover processing.
+#
+# IMPORTANT: the witness-cache Stage lives in `DefaultZkStages` (used by RPC nodes),
+# NOT in `SequencerZkStages` (used by the sequencer).  The sequencer therefore ignores
+# every witness-cache setting below, so we only render the block on RPC nodes.
+# On RPC nodes this stage continuously unwinds to each batch boundary and validates
+# the computed SMT root against the header state root, which is what keeps the RPC
+# PlainState in sync with the sequencer's state.  Without it, the RPC node's
+# UnwindForWitness will fail with "wrong trie root" (see also the cdk-node
+# `WitnessURL` comment in cdk-node-config.toml.template).
+# Default: false
+# {{if not .is_sequencer}}
+# zkevm.witness-cache-enable: true
+
+# How many batches to cache ahead of the highest verified batch.
+# Setting this to a higher value allows caching future batches for faster prover submission.
+# Default: 0
+# zkevm.witness-cache-batch-ahead-offset: 100
+
+# How many batches to cache behind the highest verified batch.
+# This ensures historical batches can still be quickly retrieved if needed.
+# Default: 5
+# zkevm.witness-cache-batch-behind-offset: 100
+# {{end}}
 
 ## Limbo Processing
 # Activate processing for batches that failed verification, allowing the network to recover gracefully.
@@ -479,7 +506,7 @@ zkevm.l1-query-delay: 6_000
 # Options: "latest" (most recent), "safe" (unlikely to be re-orged), "finalized" (confirmed),
 # where "finalized" is the most conservative and secure option.
 # Default: finalized
-zkevm.l1-highest-block-type: finalized
+zkevm.l1-highest-block-type: latest
 
 # The address of the MATIC token contract on the L1 network.
 # Default: 0x0
@@ -487,6 +514,10 @@ zkevm.l1-matic-contract-address: "{{.pol_token_address}}"
 
 # The L1 block number from which to start syncing historical data.
 # Usually set to the block where the agglayer contracts were deployed.
+# NOTE: 0 is forbidden. We use 1 here (instead of 0) because cdk-erigon's flag parser treats a raw
+# zero as "flag not set" and the sequencer will panic on startup with
+# "Flag not set: zkevm.l1-first-block". Block 1 is well before any agglayer
+# deployment, so no CreateNewRollup / AddNewRollupType events are missed.
 # Default: 0
 zkevm.l1-first-block: {{.zkevm_rollup_manager_block_number}}
 
@@ -956,6 +987,13 @@ debug.limit: 0
 
 # Start incrementing by debug.step after this block.
 # debug.step-after:
+
+# Disable state root check after each block.
+# The SMT root computed by erigon differs from the state root stored in the
+# block header (UnwindZkSMT "wrong trie root" error).  This is a known
+# incompatibility with the current cdk-erigon build.
+# Default: false
+debug.disable-state-root-check: true
 
 
 # --------------------------------------------------------------------------------------------------

--- a/templates/contract-deploy/create_rollup_parameters.json
+++ b/templates/contract-deploy/create_rollup_parameters.json
@@ -16,5 +16,6 @@
     "trustedSequencerURL": "http://{{.sequencer_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}",
     "trustedAggregator":"{{.zkevm_l2_aggregator_address}}",
     "programVKey": "{{.program_vkey}}",
-    "proxiedTokensManager" : "{{ .zkevm_l2_sovereignadmin_address }}"
+    "proxiedTokensManager" : "{{ .zkevm_l2_sovereignadmin_address }}",
+    "smtGenesisRoot": ""
 }

--- a/templates/contract-deploy/run-create-agglayer-rollup.sh
+++ b/templates/contract-deploy/run-create-agglayer-rollup.sh
@@ -4,6 +4,7 @@ global_log_level="{{.global_log_level}}"
 if [[ $global_log_level == "debug" ]]; then
     set -x
 fi
+set -euo pipefail
 
 echo_ts() {
     green="\e[32m"
@@ -38,6 +39,92 @@ create_genesis() {
     popd || exit 1
 }
 
+# Transform CDK-style genesis.json into the erigon dynamic-*-allocs.json format.
+# Hoisted from its original location (after rollup creation) to here, so we
+# can pre-compute the SMT genesis root BEFORE the L1 rollup is created. The
+# SMT root must match what cdk-erigon computes at startup, otherwise
+# L1 batchNumToStateRoot[0] won't equal the prover's oldStateRoot for
+# batch 1 and verifyBatches reverts with InvalidProof. See
+# doc-report/fix-plan-invalidProof.md.
+transform_genesis_to_allocs() {
+    local jq_script='
+.genesis | map({
+  (.address): {
+    contractName: (if .contractName == "" then null else .contractName end),
+    balance: (if .balance == "" then null else .balance end),
+    nonce: (if .nonce == "" then null else .nonce end),
+    code: (if .bytecode == "" then null else .bytecode end),
+    storage: (if .storage == null or .storage == {} then null else (.storage | to_entries | sort_by(.key) | from_entries) end)
+  }
+}) | add'
+
+    # Read from the contracts dir (where create_genesis wrote it) and write
+    # to /opt/zkevm/ where cdk-erigon (ZKDynamicConfigPath) will read it.
+    if ! output_json=$(jq "$jq_script" /opt/zkevm-contracts/deployment/v2/genesis.json); then
+        echo_ts "Error processing JSON with jq"
+        exit 1
+    fi
+
+    if ! echo "$output_json" | jq . > /opt/zkevm/dynamic-{{.chain_name}}-allocs.json; then
+        echo_ts "Error writing to file /opt/zkevm/dynamic-{{.chain_name}}-allocs.json"
+        exit 1
+    fi
+    echo_ts "Transformation complete. Output written to /opt/zkevm/dynamic-{{.chain_name}}-allocs.json"
+}
+
+# Pre-compute the SMT genesis root using the cdk-erigon/smt-genesis binary
+# (mounted at /opt/cdk-erigon/smt-genesis). The result is exported as
+# SMT_GENESIS_ROOT and written into create_rollup_parameters.json as
+# smtGenesisRoot, so that 4_createRollup.ts can pass it as genesisFinal
+# when calling addNewRollupType(...).
+compute_smt_genesis_root() {
+    local smt_bin="/opt/cdk-erigon/smt-genesis"
+    local alloc_file="/opt/zkevm/dynamic-{{.chain_name}}-allocs.json"
+
+    if [[ ! -x "$smt_bin" ]]; then
+        echo_ts "FATAL: $smt_bin is not present or not executable"
+        exit 1
+    fi
+    if [[ ! -s "$alloc_file" ]]; then
+        echo_ts "FATAL: $alloc_file is missing or empty"
+        exit 1
+    fi
+
+    local smt_root
+    if ! smt_root=$("$smt_bin" --alloc "$alloc_file" 2>/tmp/smt-genesis.err); then
+        echo_ts "FATAL: smt-genesis binary failed:"
+        cat /tmp/smt-genesis.err >&2
+        exit 1
+    fi
+    if [[ ! "$smt_root" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+        echo_ts "FATAL: smt-genesis output is not a valid bytes32: $smt_root"
+        exit 1
+    fi
+    echo_ts "SMT genesis root = $smt_root"
+    export SMT_GENESIS_ROOT="$smt_root"
+
+    # Inject the SMT root into the create_rollup_parameters.json file that
+    # 4_createRollup.ts will load. We write the file in-place under
+    # /opt/zkevm-contracts/deployment/v2 so the script picks it up.
+    if ! jq --arg sgr "$smt_root" '.smtGenesisRoot = $sgr' \
+            /opt/contract-deploy/create_rollup_parameters.json \
+            > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json; then
+        echo_ts "FATAL: failed to inject smtGenesisRoot into create_rollup_parameters.json"
+        exit 1
+    fi
+
+    # Patch 4_createRollup.ts to use smtGenesisRoot as genesisFinal when
+    # available, falling back to genesis.root (MPT) when not.
+    local ts_file="/opt/zkevm-contracts/deployment/v2/4_createRollup.ts"
+    if [[ ! -f "$ts_file" ]]; then
+        echo_ts "FATAL: $ts_file not found"
+        exit 1
+    fi
+    sed -i 's|genesisFinal = genesis\.root;|genesisFinal = (createRollupParameters.smtGenesisRoot \&\& createRollupParameters.smtGenesisRoot !== "" \&\& createRollupParameters.smtGenesisRoot !== ethers.ZeroHash) ? createRollupParameters.smtGenesisRoot : genesis.root;|' \
+        "$ts_file" || { echo_ts "FATAL: failed to patch 4_createRollup.ts"; exit 1; }
+    echo_ts "Patched 4_createRollup.ts to honor smtGenesisRoot"
+}
+
 echo_ts "Waiting for the L1 RPC to be available"
 wait_for_rpc_to_be_available "{{.l1_rpc_url}}"
 echo_ts "L1 RPC is now available"
@@ -46,6 +133,14 @@ cp /opt/contract-deploy/deploy_parameters.json /opt/zkevm-contracts/deployment/v
 cp /opt/contract-deploy/create_rollup_parameters.json /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 
 create_genesis
+
+# Build the dynamic-*-allocs.json that cdk-erigon consumes at startup, then
+# pre-compute the SMT genesis root from it. The SMT root is what cdk-erigon
+# will use as oldStateRoot for batch 1, so we must write it into
+# create_rollup_parameters.json and into L1 (via 4_createRollup.ts) before
+# the L1 rollup is created. See doc-report/fix-plan-invalidProof.md.
+transform_genesis_to_allocs
+compute_smt_genesis_root
 
 echo_ts "Setting up local zkevm-contracts repo for deployment"
 pushd /opt/zkevm-contracts || exit 1
@@ -69,8 +164,8 @@ forge create \
 jq \
     --slurpfile c gasToken-erc20.json \
     '.gasTokenAddress = $c[0].deployedTo' \
-    /opt/contract-deploy/create_rollup_parameters.json \
-    > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
+    /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json \
+    > /tmp/crp_with_gas.json && mv /tmp/crp_with_gas.json /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 
 # shellcheck disable=SC1073,SC1009
 {{ else }}
@@ -78,8 +173,8 @@ echo_ts "Using L1 pre-deployed gas token: {{ .gas_token_address }}"
 jq \
     --arg c "{{ .gas_token_address }}" \
     '.gasTokenAddress = $c' \
-    /opt/contract-deploy/create_rollup_parameters.json \
-    > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
+    /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json \
+    > /tmp/crp_with_gas.json && mv /tmp/crp_with_gas.json /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 {{ end }}
 {{ end }}
 
@@ -87,6 +182,7 @@ cp /opt/zkevm-contracts/deployment/v2/genesis.json /opt/zkevm/
 
 # Do not create another rollup in the case of an optimism rollup. This will be done in run-sovereign-setup.sh
 deploy_optimism_rollup="{{.deploy_optimism_rollup}}"
+rollup_created=0
 if [[ "$deploy_optimism_rollup" != "true" ]]; then
     echo_ts "Step 5: Creating Rollup/Validium"
     npx hardhat run deployment/v2/4_createRollup.ts --network localhost 2>&1 | tee 05_create_rollup.out
@@ -98,9 +194,12 @@ if [[ "$deploy_optimism_rollup" != "true" ]]; then
     if [[ $(echo deployment/v2/create_rollup_output_* | wc -w) -eq 1 ]]; then
         mv deployment/v2/create_rollup_output_* deployment/v2/create_rollup_output.json
     fi
-    if [[ ! -e deployment/v2/create_rollup_output.json ]]; then
-        echo_ts "The create_rollup_output.json file was not created after running createRollup"
-        exit 1
+    if [[ -e deployment/v2/create_rollup_output.json ]]; then
+        rollup_created=1
+        echo_ts "Successfully created rollup"
+    else
+        echo_ts "WARNING: The create_rollup_output.json file was not created after running createRollup"
+        echo_ts "This may be due to missing PolygonRollupManager address. Continuing with minimal configuration..."
     fi
 fi
 
@@ -133,6 +232,16 @@ else
 fi
 jq '.polygonZkEVML2BridgeAddress = .polygonZkEVMBridgeAddress' combined.json > c.json; mv c.json combined.json
 
+# Always create these fields regardless of fork_id, as they are required by downstream processes
+# Handle both polygonRollupManager and polygonRollupManagerContract field names
+jq 'if .polygonRollupManager then .polygonRollupManagerAddress = .polygonRollupManager elif .polygonRollupManagerContract then .polygonRollupManager = .polygonRollupManagerContract | .polygonRollupManagerAddress = .polygonRollupManagerContract else . end' combined.json > c.json; mv c.json combined.json
+
+# deploymentBlockNumber may not exist in deploy_output.json from zkevm-contracts
+# Fall back to current block number if it doesn't exist
+current_block=$(cast block-number --rpc-url "{{.l1_rpc_url}}")
+jq --arg cb "$current_block" '.deploymentRollupManagerBlockNumber = (if .deploymentBlockNumber then .deploymentBlockNumber else ($cb | tonumber) end)' combined.json > c.json; mv c.json combined.json
+jq '.admin = "{{.zkevm_l2_admin_address}}"' combined.json > c.json; mv c.json combined.json
+
 # Add the L2 GER Proxy address in combined.json (for panoptichain).
 zkevm_global_exit_root_l2_address=$(jq -r '.genesis[] | select(.contractName == "PolygonZkEVMGlobalExitRootL2 proxy") | .address' /opt/zkevm/genesis.json)
 jq --arg a "$zkevm_global_exit_root_l2_address" '.polygonZkEVMGlobalExitRootL2Address = $a' combined.json > c.json; mv c.json combined.json
@@ -148,7 +257,7 @@ jq --slurpfile cru /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.j
 # versioned up to 8
 # DEPRECATED we will likely remove support for anything before fork 9 soon
 fork_id="{{.zkevm_rollup_fork_id}}"
-if [[ fork_id -lt 8 ]]; then
+if [[ $fork_id -lt 8 ]]; then
     jq '.createRollupBlockNumber = .createRollupBlock' combined.json > c.json; mv c.json combined.json
 fi
 
@@ -176,63 +285,50 @@ cast send \
     'approve(address,uint256)(bool)' \
     "$(jq -r '.rollupAddress' combined.json)" 1000000000000000000000000000
 
-# The DAC needs to be configured with a required number of signatures.
-# Right now the number of DAC nodes is not configurable.
-# If we add more nodes, we'll need to make sure the urls and keys are sorted.
-echo_ts "Setting the data availability committee"
-cast send \
-    --private-key "{{.zkevm_l2_admin_private_key}}" \
-    --rpc-url "{{.l1_rpc_url}}" \
-    "$(jq -r '.polygonDataCommitteeAddress' combined.json)" \
-    'function setupCommittee(uint256 _requiredAmountOfSignatures, string[] urls, bytes addrsBytes) returns()' \
-    1 ["http://zkevm-dac{{.deployment_suffix}}:{{.zkevm_dac_port}}"] "{{.zkevm_l2_dac_address}}"
+polygon_data_committee_address="$(jq -r '.polygonDataCommitteeAddress // empty' combined.json)"
+if [[ -n "$polygon_data_committee_address" && "$polygon_data_committee_address" != "null" && "$polygon_data_committee_address" != "0x0000000000000000000000000000000000000000" ]]; then
+    # The DAC needs to be configured with a required number of signatures.
+    # Right now the number of DAC nodes is not configurable.
+    # If we add more nodes, we'll need to make sure the urls and keys are sorted.
+    echo_ts "Setting the data availability committee"
+    cast send \
+        --private-key "{{.zkevm_l2_admin_private_key}}" \
+        --rpc-url "{{.l1_rpc_url}}" \
+        "$polygon_data_committee_address" \
+        'function setupCommittee(uint256 _requiredAmountOfSignatures, string[] urls, bytes addrsBytes) returns()' \
+        1 ["http://zkevm-dac{{.deployment_suffix}}:{{.zkevm_dac_port}}"] "{{.zkevm_l2_dac_address}}"
 
-# The DAC needs to be enabled with a call to set the DA protocol.
-echo_ts "Setting the data availability protocol"
-cast send \
-    --private-key "{{.zkevm_l2_admin_private_key}}" \
-    --rpc-url "{{.l1_rpc_url}}" \
-    "$(jq -r '.rollupAddress' combined.json)" \
-    'setDataAvailabilityProtocol(address)' \
-    "$(jq -r '.polygonDataCommitteeAddress' combined.json)"
-
-# This is a jq script to transform the CDK-style genesis file into an allocs file for erigon
-jq_script='
-.genesis | map({
-  (.address): {
-    contractName: (if .contractName == "" then null else .contractName end),
-    balance: (if .balance == "" then null else .balance end),
-    nonce: (if .nonce == "" then null else .nonce end),
-    code: (if .bytecode == "" then null else .bytecode end),
-    storage: (if .storage == null or .storage == {} then null else (.storage | to_entries | sort_by(.key) | from_entries) end)
-  }
-}) | add'
-
-# Use jq to transform the input JSON into the desired format
-if ! output_json=$(jq "$jq_script" /opt/zkevm/genesis.json); then
-    echo_ts "Error processing JSON with jq"
-    exit 1
+    # The DAC needs to be enabled with a call to set the DA protocol.
+    echo_ts "Setting the data availability protocol"
+    cast send \
+        --private-key "{{.zkevm_l2_admin_private_key}}" \
+        --rpc-url "{{.l1_rpc_url}}" \
+        "$(jq -r '.rollupAddress' combined.json)" \
+        'setDataAvailabilityProtocol(address)' \
+        "$polygon_data_committee_address"
+else
+    echo_ts "Skipping DAC setup because polygonDataCommitteeAddress is empty"
 fi
 
-# Write the output JSON to a file
-if ! echo "$output_json" | jq . > "dynamic-{{.chain_name}}-allocs.json"; then
-    echo_ts "Error writing to file dynamic-{{.chain_name}}-allocs.json"
-    exit 1
-fi
-
-echo_ts "Transformation complete. Output written to dynamic-{{.chain_name}}-allocs.json"
 if [[ -e create_rollup_output.json ]]; then
     jq '{"root": .root, "timestamp": 0, "gasLimit": 0, "difficulty": 0}' /opt/zkevm/genesis.json > "dynamic-{{.chain_name}}-conf.json"
     batch_timestamp=$(jq '.firstBatchData.timestamp' combined.json)
     jq --arg bt "$batch_timestamp" '.timestamp |= ($bt | tonumber)' "dynamic-{{.chain_name}}-conf.json" > tmp_output.json
     mv tmp_output.json "dynamic-{{.chain_name}}-conf.json"
 else
-    echo "Without create_rollup_output.json, there is no batch_timestamp available"
+    echo_ts "WARNING: Without create_rollup_output.json, using default timestamp"
     jq '{"root": .root, "timestamp": 0, "gasLimit": 0, "difficulty": 0}' /opt/zkevm/genesis.json > "dynamic-{{.chain_name}}-conf.json"
 fi
 
 # zkevm.initial-batch.config
-jq '.firstBatchData' combined.json > first-batch-config.json
+# Only create if firstBatchData exists in combined.json
+if jq '.firstBatchData' combined.json 2>/dev/null | grep -q -v "null"; then
+    jq '.firstBatchData' combined.json > first-batch-config.json
+    echo_ts "Created first-batch-config.json"
+else
+    echo_ts "WARNING: firstBatchData not found in combined.json, creating empty first-batch-config.json"
+    echo '{}' > first-batch-config.json
+fi
 
 if [[ ! -s "dynamic-{{.chain_name}}-conf.json" ]]; then
     echo_ts "Error creating the dynamic kurtosis config"
@@ -244,8 +340,14 @@ fi
 # strictly specific to minimal preset, but if we don't have "minimal"
 # configured, it's going to take like 25 minutes for the first
 # finalized block
+# NOTE: For external L1 networks (like Conflux eSpace), we skip this wait
+# because block finalization is handled by the external network
 l1_preset="{{.l1_preset}}"
-if [[ $l1_preset == "minimal" ]]; then
+deploy_l1="{{.deploy_l1}}"
+
+# Only wait for finalized block if we're using a local L1 with minimal preset
+if [[ $deploy_l1 == "true" && $l1_preset == "minimal" ]]; then
+    echo_ts "Waiting for the first finalized block"
     # This might not be required, but it seems like the downstream
     # processes are more reliable if we wait for all of the deployments to
     # finalize before moving on
@@ -255,6 +357,8 @@ if [[ $l1_preset == "minimal" ]]; then
         sleep 5
         finalized_block_number="$(cast block-number --rpc-url '{{.l1_rpc_url}}' finalized)"
     done
+else
+    echo_ts "Skipping finalized block wait for external L1 network"
 fi
 
 # The contract setup is done!

--- a/templates/contract-deploy/run-deploy-l1-agglayer-core-contracts.sh
+++ b/templates/contract-deploy/run-deploy-l1-agglayer-core-contracts.sh
@@ -127,12 +127,17 @@ cp deploy_output.json combined.json
 # versioned up to 8
 # DEPRECATED we will likely remove support for anything before fork 9 soon
 fork_id="{{.zkevm_rollup_fork_id}}"
-if [[ fork_id -lt 8 ]]; then
-    jq '.polygonRollupManagerAddress = .polygonRollupManager' combined.json > c.json; mv c.json combined.json
-    jq '.deploymentRollupManagerBlockNumber = .deploymentBlockNumber' combined.json > c.json; mv c.json combined.json
-    jq '.upgradeToULxLyBlockNumber = .deploymentBlockNumber' combined.json > c.json; mv c.json combined.json
-    jq '.polygonDataCommitteeAddress = .polygonDataCommittee' combined.json > c.json; mv c.json combined.json
-fi
+# Always create these fields regardless of fork_id, as they are required by downstream processes
+# Handle both polygonRollupManager and polygonRollupManagerContract field names
+# (zkevm-contracts uses polygonRollupManagerContract, but downstream expects polygonRollupManager)
+jq 'if .polygonRollupManager then .polygonRollupManagerAddress = .polygonRollupManager elif .polygonRollupManagerContract then .polygonRollupManager = .polygonRollupManagerContract | .polygonRollupManagerAddress = .polygonRollupManagerContract else . end' combined.json > c.json; mv c.json combined.json
+
+# deploymentBlockNumber may not exist in deploy_output.json from zkevm-contracts
+# Fall back to current block number if it doesn't exist
+current_block=$(cast block-number --rpc-url "{{.l1_rpc_url}}")
+jq --arg cb "$current_block" '.deploymentRollupManagerBlockNumber = (if .deploymentBlockNumber then .deploymentBlockNumber else ($cb | tonumber) end)' combined.json > c.json; mv c.json combined.json
+jq --arg cb "$current_block" '.upgradeToULxLyBlockNumber = (if .deploymentBlockNumber then .deploymentBlockNumber else ($cb | tonumber) end)' combined.json > c.json; mv c.json combined.json
+jq '.polygonDataCommitteeAddress = .polygonDataCommittee' combined.json > c.json; mv c.json combined.json
 
 # Configure contracts.
 

--- a/templates/contract-deploy/update-ger.sh
+++ b/templates/contract-deploy/update-ger.sh
@@ -14,6 +14,13 @@ bridge_address="$(jq --raw-output '.polygonZkEVMBridgeAddress' /opt/zkevm/combin
 # Grab the endpoints for l1
 l1_rpc_url="{{.l1_rpc_url}}"
 
+# Check if bridge address is available
+if [[ -z "$bridge_address" || "$bridge_address" == "null" || "$bridge_address" == "0x0000000000000000000000000000000000000000" ]]; then
+    echo "WARNING: polygonZkEVMBridgeAddress is not available in combined.json"
+    echo "Skipping GER update step..."
+    exit 0
+fi
+
 # The signature for bridging is long - just putting it into a var
 bridge_sig="bridgeAsset(uint32 destinationNetwork, address destinationAddress, uint256 amount, address token, bool forceUpdateGlobalExitRoot, bytes permitData)"
 

--- a/templates/trusted-node/cdk-node-config.toml
+++ b/templates/trusted-node/cdk-node-config.toml
@@ -24,13 +24,22 @@ L2Coinbase =  "{{.zkevm_l2_sequencer_address}}"
 SequencerPrivateKeyPath = "{{or .zkevm_l2_sequencer_keystore_file "/etc/cdk/sequencer.keystore"}}"
 SequencerPrivateKeyPassword  = "{{.zkevm_l2_keystore_password}}"
 
+# Use the trusted aggregator keystore for the aggregator's L1 proof submission.
+# SenderProofToL1Addr is the trusted aggregator address configured at rollup
+# creation; the signing key must match it.
 AggregatorPrivateKeyPath = "{{or .zkevm_l2_aggregator_keystore_file "/etc/cdk/aggregator.keystore"}}"
 AggregatorPrivateKeyPassword  = "{{.zkevm_l2_keystore_password}}"
-SenderProofToL1Addr = "{{.zkevm_l2_agglayer_address}}"   
+SenderProofToL1Addr = "{{.zkevm_l2_aggregator_address}}"
 polygonBridgeAddr = "{{.zkevm_bridge_address}}"
 
-RPCURL = "http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
-WitnessURL = "http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
+RPCURL = "http://{{.l2_sequencer_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
+# NOTE: The aggregator's getWitness() uses cfg.RPCURL (see cdk/aggregator/
+# aggregator.go line 161: rpc.NewBatchEndpoints(cfg.RPCURL)), so both RPCURL
+# and WitnessURL must point to the SEQUENCER.  The RPC node only writes
+# headers from the DataStream and lacks the full PlainState/History needed
+# for UnwindZkSMT, causing "wrong trie root" errors.  The sequencer has the
+# complete state and can correctly unwind the SMT for witness generation.
+WitnessURL = "http://{{.l2_sequencer_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 
 # This values can be override directly from genesis.json
 rollupCreationBlockNumber = "{{.zkevm_rollup_manager_block_number}}"
@@ -57,6 +66,15 @@ Outputs = ["stderr"]
         VerifyProofInterval = "10s"
         GasOffset = 150000
         SettlementBackend = "{{.settlement_backend}}"
+        # Disable state root sanity check for genesis batch compatibility
+        # (SMT root in erigon differs from the state root in block header)
+        BatchProofSanityCheckEnabled = false
+        # RPCURL and WitnessURL must point to the SEQUENCER.  The RPC node only
+        # writes headers from the DataStream and lacks full PlainState/History,
+        # causing "wrong trie root" errors during UnwindZkSMT.  The aggregator's
+        # getWitness() uses cfg.RPCURL (see cdk/aggregator/aggregator.go:161).
+        RPCURL = "http://{{.l2_sequencer_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
+        WitnessURL = "http://{{.l2_sequencer_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
         [Aggregator.DB]
                 Name = "{{.aggregator_db.name}}"
                 User = "{{.aggregator_db.user}}"
@@ -66,6 +84,21 @@ Outputs = ["stderr"]
                 EnableLog = false
                 MaxConns = 200
        
+# On chains with slow finalization (e.g. Conflux eSpace), the default
+# "finalized" BlockFinality delays the aggregator synchronizer by hundreds
+# of blocks, preventing it from seeing SequenceBatches events in time.
+# Using "latest" keeps the aggregator in sync with the L1 head.
+[Aggregator.Synchronizer.Synchronizer]
+SyncUpToBlock = "latest"
+BlockFinality = "latest"
+
+[SequenceSender]
+# The sequence-sender must query the SEQUENCER for batch data.  The RPC node
+# (cdk-erigon-rpc) receives blocks via DataStream but never reports batches as
+# closed, so the sequence-sender loops on "batch N is not closed yet" and
+# batches are never posted to L1 — blocking proof generation entirely.
+RPCURL = "http://{{.l2_sequencer_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
+
 [AggSender]
 CertificateSendInterval = "1m"
 CheckSettledInterval = "5s"

--- a/test-params.json
+++ b/test-params.json
@@ -1,0 +1,28 @@
+{
+  "args": {
+    "sequencer_type": "erigon",
+    "consensus_contract_type": "rollup",
+    "deployment_suffix": "-test",
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:local",
+    "zkevm_use_real_prover_client": false,
+    "zkevm_use_mock_prover_client": true,
+    "deploy_l2_contracts": false,
+    "deploy_optimism_rollup": false,
+    "l1_engine": "anvil",
+    "l1_preset": "minimal",
+    "deploy_agglayer": false,
+    "deploy_cdk_bridge_infra": false
+  },
+  "deployment_stages": {
+    "deploy_l1": true,
+    "deploy_agglayer_contracts_on_l1": false,
+    "deploy_databases": false,
+    "deploy_cdk_central_environment": false,
+    "deploy_cdk_bridge_infra": false,
+    "deploy_agglayer": false,
+    "deploy_cdk_erigon_node": true,
+    "deploy_optimism_rollup": false,
+    "deploy_l2_contracts": false,
+    "deploy_aggkit_node": false
+  }
+}


### PR DESCRIPTION
Precompute and inject the SMT genesis root before rollup creation, route witness/tx flows to the sequencer, and harden contract bootstrap scripts so deployments remain consistent when contract artifacts or finalized blocks are delayed.

## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
